### PR TITLE
Modtime and size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__
+test/


### PR DESCRIPTION
This PR implements the changes noted by the FIXME, although many other things were done in pursuit of such. They include:
* Complete replacement of os.path manipulations to use `pathlib.Path`.
* Replacement of blind rglob call with a recursive generator which yields ebooks that are not inside the chosen output directory.
* Creation of an object to represent books to be converted, featuring total ordering based on file size, bool telling whether conversion should be done, and some path conveniences.
* usage of `os.utime` to copy modification and access timestamps from source to destination.
* Other clean-up related to paths, including making everything absolute before it hits pandoc. This removes the need for os.chdir calls.

Testing has confirmed that the loop at least runs and does seem to be skipping things it already converted, but various file system implementations might make this a bit finicky. It may be reasonable to remove the utime calls if a proper threshold for modtime can be obtained.